### PR TITLE
Ikfj patch 1

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -4,5 +4,3 @@ dependencies:
   - r-base=3.6
   - r-tidyverse
   - r-dygraphs
-  - r-xts
-  - r-zoo

--- a/environment.yml
+++ b/environment.yml
@@ -3,3 +3,6 @@ channels:
 dependencies:
   - r-base=3.6
   - r-tidyverse
+  - r-dygraphs
+  - r-xts
+  - r-zoo


### PR DESCRIPTION
To avoid "x86_64-conda-linux-gnu-cc: not found", Install the dependencies of coefplot that need compilation via conda.